### PR TITLE
Fix readme links (demo/realtime-txt2img)

### DIFF
--- a/demo/realtime-txt2img/README-ja.md
+++ b/demo/realtime-txt2img/README-ja.md
@@ -28,4 +28,4 @@ python main.py
 
 KohakuV2 モデルを提供していただいたKohaku BlueLeaf 様 ([@KBlueleaf](https://twitter.com/KBlueleaf))、[SD-Turbo](https://arxiv.org/abs/2311.17042)を提供していただいた[Stability AI](https://ja.stability.ai/)様に心より感謝いたします。
 
-KohakuV2 モデルは [Civitai](https://civitai.com/models/136268/kohaku-v2) と [Hugging Face](https://huggingface.co/stabilityai/sd-turbo) からダウンロードでき、[SD-Turbo](https://arxiv.org/abs/2311.17042) は Hugging Faceで使用可能です。
+KohakuV2 モデルは [Civitai](https://civitai.com/models/136268/kohaku-v2) と [Hugging Face](https://huggingface.co/KBlueLeaf/kohaku-v2.1) からダウンロードでき、[SD-Turbo](https://arxiv.org/abs/2311.17042) は [Hugging Face](https://huggingface.co/stabilityai/sd-turbo) で使用可能です。

--- a/demo/realtime-txt2img/README.md
+++ b/demo/realtime-txt2img/README.md
@@ -28,6 +28,6 @@ The video and image demos in this GitHub repository were generated using [kohaku
 
 Special thanks to Kohaku BlueLeaf ([@KBlueleaf](https://twitter.com/KBlueleaf)) for providing the KohakuV2 model, and to [Stability AI](https://ja.stability.ai/) for [SD-Turbo](https://arxiv.org/abs/2311.17042).
 
- KohakuV2 Models can be downloaded from  [Civitai](https://civitai.com/models/136268/kohaku-v2)  and [Hugging Face](https://huggingface.co/stabilityai/sd-turbo).
+ KohakuV2 Models can be downloaded from  [Civitai](https://civitai.com/models/136268/kohaku-v2)  and [Hugging Face](https://huggingface.co/KBlueLeaf/kohaku-v2.1).
 
- [SD-Turbo](https://arxiv.org/abs/2311.17042) is also available on Hugging Face.
+ [SD-Turbo](https://arxiv.org/abs/2311.17042) is also available on [Hugging Face](https://huggingface.co/stabilityai/sd-turbo).


### PR DESCRIPTION
Hello, This is a very cool project!

I was reading the README for `demo/realtime-txt2img` and noticed that it needed a correction regarding the link, so I fixed it.

Would appreciate it if you could take a look and let me know your thoughts.

Thank you!