### PR TITLE
chore(readme): Enclose URL in Quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Install StreamDiffusion
 
 ```bash
 #for Latest Version (recommended)
-pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]
+pip install "git+https://github.com/cumulo-autumn/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]"
 
 
 #or


### PR DESCRIPTION
```
$ pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]

zsh: no matches found: git+https://github.com/cumulo-autumn/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]
```

I am trying to install a Python package from a Git repository using pip with zsh. The error message zsh: no matches found typically occurs in the Z shell (zsh) when it tries to interpret special characters. In the command, the square brackets ([]) are likely causing the issue, as zsh treats them as a pattern-matching character.

To fix this, we can either escape the square brackets or enclose the entire URL in quotes.