### PR TITLE
[examples] fix multiprocessing on Linux

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ If you want to maximize performance, you need to install with following steps ex
 
 ## `screen/`
 
-Take a screen capture and process it. **This script only works on Windows.**
+Take a screen capture and process it.
 
 When you run the script, a translucent window appears. Position it at where you want to capture the screen and press the enter key to finalize the capture area.
 

--- a/examples/optimal-performance/multi.py
+++ b/examples/optimal-performance/multi.py
@@ -3,7 +3,7 @@ import sys
 import threading
 import time
 import tkinter as tk
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, get_context
 from typing import List, Literal
 
 import fire
@@ -174,17 +174,20 @@ def main(
     """
     Main function to start the image generation and viewer processes.
     """
-    queue = Queue()
-    fps_queue = Queue()
-    process1 = Process(
+    ctx = get_context('spawn')
+    queue = ctx.Queue()
+    fps_queue = ctx.Queue()
+    process1 = ctx.Process(
         target=image_generation_process,
         args=(queue, fps_queue, prompt, model_id_or_path, batch_size, acceleration),
     )
     process1.start()
 
-    process2 = Process(target=receive_images, args=(queue, fps_queue))
+    process2 = ctx.Process(target=receive_images, args=(queue, fps_queue))
     process2.start()
 
+    process1.join()
+    process2.join()
 
 if __name__ == "__main__":
     fire.Fire(main)

--- a/examples/optimal-performance/single.py
+++ b/examples/optimal-performance/single.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import time
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, get_context
 from typing import Literal
 
 import fire
@@ -72,17 +72,20 @@ def main(
     """
     Main function to start the image generation and viewer processes.
     """
-    queue = Queue()
-    fps_queue = Queue()
-    process1 = Process(
+    ctx = get_context('spawn')
+    queue = ctx.Queue()
+    fps_queue = ctx.Queue()
+    process1 = ctx.Process(
         target=image_generation_process,
         args=(queue, fps_queue, prompt, model_id_or_path, acceleration),
     )
     process1.start()
 
-    process2 = Process(target=receive_images, args=(queue, fps_queue))
+    process2 = ctx.Process(target=receive_images, args=(queue, fps_queue))
     process2.start()
 
+    process1.join()
+    process2.join()
 
 if __name__ == "__main__":
     fire.Fire(main)

--- a/examples/screen/main.py
+++ b/examples/screen/main.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 import threading
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, get_context
 from typing import List, Literal, Dict, Optional
 import torch
 import PIL.Image
@@ -216,10 +216,10 @@ def main(
     Main function to start the image generation and viewer processes.
     """
     monitor = dummy_screen(width, height)
-
-    queue = Queue()
-    fps_queue = Queue()
-    process1 = Process(
+    ctx = get_context('spawn')
+    queue = ctx.Queue()
+    fps_queue = ctx.Queue()
+    process1 = ctx.Process(
         target=image_generation_process,
         args=(
             queue,
@@ -246,9 +246,11 @@ def main(
     )
     process1.start()
 
-    process2 = Process(target=receive_images, args=(queue, fps_queue))
+    process2 = ctx.Process(target=receive_images, args=(queue, fps_queue))
     process2.start()
 
+    process1.join()
+    process2.join()
 
 if __name__ == "__main__":
     fire.Fire(main)


### PR DESCRIPTION
1. use multiprocessing context to specify the `"spawn"` start method, which fixes the `RuntimeError: Cannot re-initialize CUDA in forked subprocess` on Linux (in Python on POSIX systems `"fork"` is currently the default, but it will change away from `"fork"` in Python 3.14 [[docs]](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods))

2. call `.join()` to wait for processes to complete (avoids exiting program immediately)

I believe this resolves issues #21 and #17. 

All the examples are now working for me, the `optimal-performance/multi.py` script is showing ~85 FPS.

OS: Ubuntu 22.04 (Linux kernel 6.2.0)
CUDA: 11.8
GPU: RTX 4090
Python: 3.10.6

@cumulo-autumn 