### PR TITLE
Fix python path to not fail if it contains spaces

### DIFF
--- a/src/streamdiffusion/pip_utils.py
+++ b/src/streamdiffusion/pip_utils.py
@@ -30,7 +30,7 @@ def is_installed(package: str) -> bool:
 
 def run_python(command: str, env: Dict[str, str] = None) -> str:
     run_kwargs = {
-        "args": f"{python} {command}",
+        "args": f"\"{python}\" {command}",
         "shell": True,
         "env": os.environ if env is None else env,
         "encoding": "utf8",


### PR DESCRIPTION
The following command listed in the README will fail if the python path contains spaces.
```
python -m streamdiffusion.tools.install-tensorrt
```
I solved this problem by enclosing the python path in double quotation marks.