### PR TITLE
Fix README for environment created with conda on Windows

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -143,6 +143,13 @@ python setup.py develop easy_install streamdiffusion[tensorrt]
 python -m streamdiffusion.tools.install-tensorrt
 ```
 
+pywin32 を再インストール
+(※※Windowsでanacondaを使用して仮想環境を作成した場合のみ必要です。)
+
+```bash
+pip install --force-reinstall pywin32
+```
+
 ### Dockerの場合(TensorRT対応)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ python setup.py develop easy_install streamdiffusion[tensorrt]
 python -m streamdiffusion.tools.install-tensorrt
 ```
 
+Reinstall pywin32
+(※※If you created your environment with conda on Windows.)
+
+```bash
+pip install --force-reinstall pywin32
+```
+
 ### Docker Installation (TensorRT Ready)
 
 ```bash


### PR DESCRIPTION
It seems that pywin32 does not install properly in environments created with conda on Windows.
We have taken a countermeasure by forcibly reinstalling pywin32 and have included this in the README.
This is a temporary measure, so if it can be solved by fixing setup.py, I think it would be better to do so.