### PR TITLE
Default LoRA_dict arguments have been changed.

### DIFF
--- a/demo/realtime-txt2img/server/config.py
+++ b/demo/realtime-txt2img/server/config.py
@@ -27,6 +27,8 @@ class Config:
     mode: Literal["txt2img", "img2img"] = "txt2img"
     # SD1.x variant model
     model_id_or_path: str = "KBlueLeaf/kohaku-v2.1"
+    # LoRA dictionary write like    field(default_factory=lambda: {'E:/stable-diffusion-webui/models/Lora_1.safetensors' : 1.0 , 'E:/stable-diffusion-webui/models/Lora_2.safetensors' : 0.2})
+    lora_dict: dict = None
     # LCM-LORA model
     lcm_lora_id: str = "latent-consistency/lcm-lora-sdv1-5"
     # TinyVAE model

--- a/demo/realtime-txt2img/server/main.py
+++ b/demo/realtime-txt2img/server/main.py
@@ -61,6 +61,7 @@ class Api:
         self.stream_diffusion = StreamDiffusionWrapper(
             mode=config.mode,
             model_id_or_path=config.model_id_or_path,
+            lora_dict = config.lora_dict,
             lcm_lora_id=config.lcm_lora_id,
             vae_id=config.vae_id,
             device=config.device,

--- a/examples/README.md
+++ b/examples/README.md
@@ -135,7 +135,7 @@ The ```--lora_dict``` is in the format ```"{'LoRA_1 file path' : LoRA_1 scale , 
 
 
 Usage : 
-```--lora_dict "{'C:/stable-diffusion-webui/models/Stable-diffusion/LoRA_1.safetensor' : 0.5 ,"E:/ComfyUI/models/LoRA_2.safetensor' : 0.7 }"``` 
+```--lora_dict "{'C:/stable-diffusion-webui/models/Stable-diffusion/LoRA_1.safetensor' : 0.5 ,'E:/ComfyUI/models/LoRA_2.safetensor' : 0.7 }"``` 
 
 ### Prompt 
 ```--prompt``` allows you to change Prompt.

--- a/examples/benchmark/multi.py
+++ b/examples/benchmark/multi.py
@@ -62,7 +62,7 @@ def run(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str, optional
         The prompt to use, by default "1girl with brown dog hair, thick glasses, smiling".
     negative_prompt : str, optional

--- a/examples/benchmark/single.py
+++ b/examples/benchmark/single.py
@@ -49,7 +49,7 @@ def run(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str, optional
         The prompt to use, by default "1girl with brown dog hair, thick glasses, smiling".
     negative_prompt : str, optional

--- a/examples/img2img/multi.py
+++ b/examples/img2img/multi.py
@@ -43,7 +43,7 @@ def main(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str
         The prompt to generate images from.
     negative_prompt : str, optional

--- a/examples/img2img/single.py
+++ b/examples/img2img/single.py
@@ -42,7 +42,7 @@ def main(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str
         The prompt to generate images from.
     negative_prompt : str, optional

--- a/examples/screen/main.py
+++ b/examples/screen/main.py
@@ -94,7 +94,7 @@ def image_generation_process(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str
         The prompt to generate images from.
     negative_prompt : str, optional

--- a/examples/txt2img/multi.py
+++ b/examples/txt2img/multi.py
@@ -35,7 +35,7 @@ def main(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str
         The prompt to generate images from.
     width : int, optional

--- a/examples/txt2img/single.py
+++ b/examples/txt2img/single.py
@@ -36,7 +36,7 @@ def main(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str
         The prompt to generate images from.
     width : int, optional

--- a/examples/vid2vid/main.py
+++ b/examples/vid2vid/main.py
@@ -41,7 +41,7 @@ def main(
     lora_dict : Optional[Dict[str, float]], optional
         The lora_dict to load, by default None.
         Keys are the LoRA names and values are the LoRA scales.
-        Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+        Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
     prompt : str
         The prompt to generate images from.
     scale : float, optional

--- a/utils/wrapper.py
+++ b/utils/wrapper.py
@@ -59,7 +59,7 @@ class StreamDiffusionWrapper:
         lora_dict : Optional[Dict[str, float]], optional
             The lora_dict to load, by default None.
             Keys are the LoRA names and values are the LoRA scales.
-            Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+            Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
         mode : Literal["img2img", "txt2img"], optional
             txt2img or img2img, by default "img2img".
         output_type : Literal["pil", "pt", "np", "latent"], optional
@@ -378,7 +378,7 @@ class StreamDiffusionWrapper:
         lora_dict : Optional[Dict[str, float]], optional
             The lora_dict to load, by default None.
             Keys are the LoRA names and values are the LoRA scales.
-            Example: {"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...}
+            Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
         lcm_lora_id : Optional[str], optional
             The lcm_lora_id to load, by default None.
         vae_id : Optional[str], optional


### PR DESCRIPTION
Default LoRA_dict arguments have been changed.

{"LoRA_1" : 0.5 , "LoRA_2" : 0.7 ,...} → {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}

クオーテーション関連のミスを修正