### PR TITLE
wrapper.py: pass prompt to img2img and optional engine_dir arg

### DIFF
--- a/utils/wrapper.py
+++ b/utils/wrapper.py
@@ -46,6 +46,7 @@ class StreamDiffusionWrapper:
         cfg_type: Literal["none", "full", "self", "initialize"] = "self",
         seed: int = 2,
         use_safety_checker: bool = False,
+        engine_dir: Optional[Union[str, Path]] = "engines",
     ):
         """
         Initializes the StreamDiffusionWrapper.
@@ -161,6 +162,7 @@ class StreamDiffusionWrapper:
             use_tiny_vae=use_tiny_vae,
             cfg_type=cfg_type,
             seed=seed,
+            engine_dir=engine_dir,
         )
 
         if device_ids is not None:
@@ -223,7 +225,7 @@ class StreamDiffusionWrapper:
             The generated image.
         """
         if self.mode == "img2img":
-            return self.img2img(image)
+            return self.img2img(image, prompt)
         else:
             return self.txt2img(prompt)
 
@@ -265,7 +267,7 @@ class StreamDiffusionWrapper:
         return image
 
     def img2img(
-        self, image: Union[str, Image.Image, torch.Tensor]
+        self, image: Union[str, Image.Image, torch.Tensor], prompt: Optional[str] = None
     ) -> Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]:
         """
         Performs img2img.
@@ -280,6 +282,9 @@ class StreamDiffusionWrapper:
         Image.Image
             The generated image.
         """
+        if prompt is not None:
+            self.stream.update_prompt(prompt)
+
         if isinstance(image, str) or isinstance(image, Image.Image):
             image = self.preprocess_image(image)
 
@@ -356,6 +361,7 @@ class StreamDiffusionWrapper:
         use_tiny_vae: bool = True,
         cfg_type: Literal["none", "full", "self", "initialize"] = "self",
         seed: int = 2,
+        engine_dir: Optional[Union[str, Path]] = "engines",
     ) -> StreamDiffusion:
         """
         Loads the model.
@@ -490,7 +496,7 @@ class StreamDiffusionWrapper:
                     else:
                         return f"{model_id_or_path}--lcm_lora-{use_lcm_lora}--tiny_vae-{use_tiny_vae}--max_batch-{max_batch_size}--min_batch-{min_batch_size}--mode-{self.mode}"
 
-                engine_dir = os.path.join("engines")
+                engine_dir = Path(engine_dir)
                 unet_path = os.path.join(
                     engine_dir,
                     create_prefix(


### PR DESCRIPTION
As address on #57 , we can modify `wrapper.py` to enable prompt on `img2img` mode  and an optional `engine_dir` argument, that's useful when running on Docker, one can re-use the compiled engines on local environment. 