### PR TITLE
Added OS check to prevent errors on non 'nt' OSes.

### DIFF
--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -1,3 +1,4 @@
+import os
 from typing import Literal, Optional
 
 import fire
@@ -41,7 +42,7 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_version_from_torch()):
         run_pip(
             "install onnx-graphsurgeon==0.3.26 --extra-index-url https://pypi.ngc.nvidia.com"
         )
-    if not is_installed("pywin32"):
+    if os.name == 'nt' and not is_installed("pywin32"):
         run_pip(
             "install pywin32"
         )


### PR DESCRIPTION
An error caused by trying to install 'pywin32' without considering the OS detection has been fixed. Tested on Ubuntu 22.04.3 and Windows 11 23H2.