### PR TITLE
only install pywin32 on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ _deps = [
     "onnxruntime==1.16.3",
     "protobuf==3.20.2",
     "colored",
-    "pywin32"
+    "pywin32;sys_platform == 'win32'"
 ]
 
 deps = {b: a for a, b in (re.findall(r"^(([^!=<>~]+)(?:[!=<>~].*)?$)", x)[0] for x in _deps)}

--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -4,6 +4,7 @@ import fire
 from packaging.version import Version
 
 from ..pip_utils import is_installed, run_pip, version
+import platform
 
 
 def get_cuda_version_from_torch() -> Optional[Literal["11", "12"]]:
@@ -41,7 +42,7 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_version_from_torch()):
         run_pip(
             "install onnx-graphsurgeon==0.3.26 --extra-index-url https://pypi.ngc.nvidia.com"
         )
-    if not is_installed("pywin32"):
+    if platform.system() == 'Windows' and not is_installed("pywin32"):
         run_pip(
             "install pywin32"
         )


### PR DESCRIPTION
Fix docker build error "ERROR: No matching distribution found for pywin32"