### PR TITLE
Fix: Remove reduntant .cpu() usage

### DIFF
--- a/utils/wrapper.py
+++ b/utils/wrapper.py
@@ -343,9 +343,9 @@ class StreamDiffusionWrapper:
             The postprocessed image.
         """
         if self.frame_buffer_size > 1:
-            return postprocess_image(image_tensor.cpu(), output_type=output_type)
+            return postprocess_image(image_tensor, output_type=output_type)
         else:
-            return postprocess_image(image_tensor.cpu(), output_type=output_type)[0]
+            return postprocess_image(image_tensor, output_type=output_type)[0]
 
     def _load_model(
         self,


### PR DESCRIPTION
This PR fixes redundant .cpu() call for a tensor which is passed to `postprocess_image()`, since that function calls .cpu() as well, resulting in multiple calls. 