### PR TITLE
PR: Fix onnx-graphsurgeon Version Issue

### DIFF
--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -40,7 +40,7 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_version_from_torch()):
         )
     if not is_installed("onnx_graphsurgeon"):
         run_pip(
-            "install onnx-graphsurgeon==0.3.26 --extra-index-url https://pypi.ngc.nvidia.com"
+            "install onnx-graphsurgeon==0.5.2 --extra-index-url https://pypi.ngc.nvidia.com"
         )
     if platform.system() == 'Windows' and not is_installed("pywin32"):
         run_pip(


### PR DESCRIPTION
## Description

This PR addresses an issue where the `onnx-graphsurgeon==0.3.26` package could not be found during the installation process. The proposed change updates the version of `onnx-graphsurgeon` to `0.5.2`, which is available and resolves the installation problem.

## Changes Made

- Updated the version of `onnx-graphsurgeon` in the `install` function from `0.3.26` to `0.5.2`:

    ```python
    if not is_installed("onnx_graphsurgeon"):
        run_pip(
            "install onnx-graphsurgeon==0.5.2 --extra-index-url https://pypi.ngc.nvidia.com"
        )
    ```

## Error Details

### Error Message

```bash
$ python -m streamdiffusion.tools.install-tensorrt
...
ERROR: Could not find a version that satisfies the requirement onnx-graphsurgeon==0.3.26 (from versions: 0.0.1.dev4, 0.0.1.dev5, 0.5.2)
ERROR: No matching distribution found for onnx-graphsurgeon==0.3.26
Error running command: -m pip install onnx-graphsurgeon==0.3.26 --extra-index-url https://pypi.ngc.nvidia.com
Traceback (most recent call last):
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/site-packages/streamdiffusion/tools/install-tensorrt.py", line 54, in <module>
    fire.Fire(install)
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/site-packages/fire/core.py", line 143, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/site-packages/fire/core.py", line 477, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/site-packages/fire/core.py", line 693, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/site-packages/streamdiffusion/tools/install-tensorrt.py", line 42, in install
    run_pip(
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/site-packages/streamdiffusion/pip_utils.py", line 52, in run_pip
    return run_python(f"-m pip {command}", env)
File "/home/xxxx/miniconda3/envs/streamdiffusion/lib/python3.10/site-packages/streamdiffusion/pip_utils.py", line 46, in run_python
    raise RuntimeError(f"Error running command: {command}")
RuntimeError: Error running command: -m pip install onnx-graphsurgeon==0.3.26 --extra-index-url https://pypi.ngc.nvidia.com

$ pip install onnx-graphsurgeon==0.3.26
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
ERROR: Could not find a version that satisfies the requirement onnx-graphsurgeon==0.3.26 (from versions: 0.0.1.dev4, 0.0.1.dev5, 0.5.2)
ERROR: No matching distribution found for onnx-graphsurgeon==0.3.26
```