### PR TITLE
Update setup.py to allow range of diffusers versions (0.24.0 - 0.29.0) [0.24.0 is incompatible with recent huggingface_hub versions)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 _deps = [
     "torch",
     "xformers",
-    "diffusers==0.24.0",
+    "diffusers>=0.24.0,<=0.29.0",
     "transformers",
     "accelerate",
     "fire",


### PR DESCRIPTION
Extended valid range for diffusers to 0.24.0 : 0.29.0 to account for new diffuser package which is required for some other newer packages. In particular, versions lower than 0.29.0 are incompatible with the huggingface_hub module. By extending the version to allow 0.29.0, these packages can co-exist again with StreamDiffusion.