### PR TITLE
Fix Docker installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN pip3 install \
     xformers \
     --index-url https://download.pytorch.org/whl/cu118
 
+RUN pip install numpy==1.26.4
+
 COPY . /streamdiffusion
 WORKDIR /streamdiffusion
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 _deps = [
     "torch",
     "xformers",
-    "diffusers==0.24.0",
+    "diffusers",
     "transformers",
     "accelerate",
     "fire",

--- a/src/streamdiffusion/acceleration/tensorrt/engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine.py
@@ -1,9 +1,9 @@
 from typing import *
 
 import torch
-from diffusers.models.autoencoder_tiny import AutoencoderTinyOutput
-from diffusers.models.unet_2d_condition import UNet2DConditionOutput
-from diffusers.models.vae import DecoderOutput
+from diffusers.models.autoencoders.autoencoder_tiny import AutoencoderTinyOutput
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionOutput
+from diffusers.models.autoencoders.vae import DecoderOutput
 from polygraphy import cuda
 
 from .utilities import Engine


### PR DESCRIPTION
Fix broken Dockerfile image so it can be used out-of-the-box.

* Pin numpy to 1.26.4
* Update diffusers to latest version and fix broken imports in `src/streamdiffusion/acceleration/tensorrt/engine.py`

Tested to work on Ubuntu Server 24.04