### PR TITLE
compatibility with TensorRT 10

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -246,17 +246,18 @@ class Engine:
             self.context = self.engine.create_execution_context()
 
     def allocate_buffers(self, shape_dict=None, device="cuda"):
-        for idx in range(trt_util.get_bindings_per_profile(self.engine)):
-            binding = self.engine[idx]
-            if shape_dict and binding in shape_dict:
-                shape = shape_dict[binding]
+        for idx in range(self.engine.num_io_tensors):
+            tensor_name = self.engine.get_tensor_name(idx)
+            if shape_dict and tensor_name in shape_dict:
+                shape = shape_dict[tensor_name]
             else:
-                shape = self.engine.get_binding_shape(binding)
-            dtype = trt.nptype(self.engine.get_binding_dtype(binding))
-            if self.engine.binding_is_input(binding):
-                self.context.set_binding_shape(idx, shape)
+                shape = self.engine.get_tensor_shape(tensor_name)
+            dtype = trt.nptype(self.engine.get_tensor_dtype(tensor_name))
+            if self.engine.get_tensor_mode(tensor_name) == trt.TensorIOMode.INPUT:
+                self.context.set_input_shape(tensor_name, shape)
+
             tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]).to(device=device)
-            self.tensors[binding] = tensor
+            self.tensors[tensor_name] = tensor
 
     def infer(self, feed_dict, stream, use_cuda_graph=False):
         for name, buf in feed_dict.items():


### PR DESCRIPTION
Following the official migration guide https://docs.nvidia.com/deeplearning/tensorrt/latest/api/migration-guide.html the`Engine.allocate_buffers` method can be updated to make this repo compatible with TensorRT 10.

This significantly simplifies dependencies, removing the need for the additional script `python -m streamdiffusion.tools.install-tensorrt`

1. Latest versions of `tensorrt`, `polygraphy` and `onnx-graphsurgeon` can be installed from PyPi.
2. TensorRT can be installed using a more modern dependency manager Poetry
```bash
poetry source add --priority=supplemental nvidia https://pypi.nvidia.com
poetry add --source nvidia tensorrt-cu12 tensorrt-cu12-libs tensorrt-cu12-bindings
```

Related issues:
https://github.com/cumulo-autumn/StreamDiffusion/issues/77
https://github.com/NVIDIA/TensorRT/issues/3050